### PR TITLE
Fix tests for authenticated calls

### DIFF
--- a/R/osmapi_request.R
+++ b/R/osmapi_request.R
@@ -5,7 +5,7 @@ osmapi_request <- function(authenticate = FALSE) {
   req <- httr2::req_user_agent(req, string = "osmapiR (https://github.com/jmaspons/osmapiR)")
 
   if (authenticate & !getOption("osmapir.R_CMD_check", FALSE)) {
-    req <- oauth_request(req)
+    req <- oauth_request(req) # nocov
   }
 
   return(req)

--- a/R/osmapi_request.R
+++ b/R/osmapi_request.R
@@ -4,7 +4,7 @@ osmapi_request <- function(authenticate = FALSE) {
   req <- httr2::req_retry(req, max_tries = 10L)
   req <- httr2::req_user_agent(req, string = "osmapiR (https://github.com/jmaspons/osmapiR)")
 
-  if (authenticate) {
+  if (authenticate & !getOption("osmapir.R_CMD_check", FALSE)) {
     req <- oauth_request(req)
   }
 

--- a/tests/testthat/mock_get_metadata_gpx/osm.org/api/0.6/gpx/3790367/details.xml
+++ b/tests/testthat/mock_get_metadata_gpx/osm.org/api/0.6/gpx/3790367/details.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="OpenStreetMap server" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+<gpx_file id="3790367" name="Airoto_Marimanha.gpx" user="jmaspons" visibility="public" pending="false" timestamp="2021-08-20T10:30:15Z" lat="42.69660229794681" lon="1.0419843904674053">
+  <description>Airoto Marimanha Oriental</description>
+  <tag>camp</tag>
+  <tag>a</tag>
+  <tag>través</tag>
+</gpx_file>
+</osm>

--- a/tests/testthat/mock_list_gpxs/osm.org/api/0.6/user/gpx_files.xml
+++ b/tests/testthat/mock_list_gpxs/osm.org/api/0.6/user/gpx_files.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="OpenStreetMap server" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+<gpx_file id="3431956" name="StJuli_DeRibelles_HostalDeLaMuga_Talaix__Sadernes.gpx" user="jmaspons" visibility="identifiable" pending="false" timestamp="2020-09-28T09:23:52Z" lat="42.333541251719" lon="2.5914327520877123">
+  <description>StJuliàDeRibelles_HostalDeLaMuga_Talaixà_Sadernes</description>
+</gpx_file>
+<gpx_file id="3472797" name="not_saved" user="jmaspons" visibility="identifiable" pending="false" timestamp="2020-10-25T12:06:03Z" lat="42.313132993876934" lon="2.5896873883903027">
+  <description>St. Aniol - Passant del Gamarús - cova dels Trabucaires - Passant d'en Llebre</description>
+</gpx_file>
+<gpx_file id="3494162" name="not_saved" user="jmaspons" visibility="identifiable" pending="false" timestamp="2020-11-07T18:18:15Z" lat="41.49835919961333" lon="2.1166683454066515">
+  <description>camins de Cerdanyola</description>
+  <tag>trailrun</tag>
+</gpx_file>
+<gpx_file id="3498170" name="bruc.gpx" user="jmaspons" visibility="identifiable" pending="false" timestamp="2020-11-11T09:58:39Z" lat="41.58796912059188" lon="1.7747229896485806">
+  <description>Corriols per les rodalies del Bruc</description>
+</gpx_file>
+<gpx_file id="3789949" name="Roca_de_la_Pena_corrent.gpx" user="jmaspons" visibility="public" pending="false" timestamp="2021-08-19T21:47:50Z" lat="42.18059817329049" lon="1.4281276892870665">
+  <description>Roca de la Pena circular</description>
+</gpx_file>
+<gpx_file id="3789948" name="Roca_de_la_Pena_des_de_Llobera.gpx" user="jmaspons" visibility="public" pending="false" timestamp="2021-08-19T21:47:07Z" lat="42.18116671778262" lon="1.4277103543281555">
+  <description>Roca de la Pena des de Llobera</description>
+</gpx_file>
+<gpx_file id="3790367" name="Airoto_Marimanha.gpx" user="jmaspons" visibility="public" pending="false" timestamp="2021-08-20T10:30:15Z" lat="42.69660229794681" lon="1.0419843904674053">
+  <description>Airoto Marimanha Oriental</description>
+  <tag>camp</tag>
+  <tag>a</tag>
+  <tag>través</tag>
+</gpx_file>
+<gpx_file id="3901854" name="Castell_Canig__refugi_d_Arag_.gpx" user="jmaspons" visibility="identifiable" pending="false" timestamp="2021-11-02T18:22:25Z" lat="42.53348727710545" lon="2.395844478160143">
+  <description>Castell - Canigó - refugi d'Aragó</description>
+</gpx_file>
+<gpx_file id="4073819" name="Bisaroques.gpx" user="jmaspons" visibility="identifiable" pending="false" timestamp="2022-01-24T07:51:46Z" lat="42.188827358186245" lon="2.5100998766720295">
+  <description>Volta circular amb corriols per traçar</description>
+</gpx_file>
+<gpx_file id="4118006" name="Perles_Figols.gpx" user="jmaspons" visibility="identifiable" pending="false" timestamp="2022-02-13T19:21:43Z" lat="42.17918783426285" lon="1.3936991896480322">
+  <description>Camins pendents d'agegir entre Perles i Fígols pel Collet de la Canal d'en Joan</description>
+</gpx_file>
+<gpx_file id="4431250" name="activity_8969751253.gpx" user="jmaspons" visibility="identifiable" pending="false" timestamp="2022-06-07T10:19:52Z" lat="42.23573558963835" lon="1.6616315860301256">
+  <description>Gósol - Vulturó per Josa del Cadí</description>
+</gpx_file>
+<gpx_file id="4431415" name="activity_8969751704.gpx" user="jmaspons" visibility="identifiable" pending="false" timestamp="2022-06-07T10:49:34Z" lat="42.28576574474573" lon="1.6366010438650846">
+  <description>Vulturó i fins més avall del refugi de St. Jordi</description>
+</gpx_file>
+<gpx_file id="4432183" name="activity_8969752023.gpx" user="jmaspons" visibility="identifiable" pending="false" timestamp="2022-06-07T16:34:34Z" lat="42.27627390995622" lon="1.818500580266118">
+  <description>Tornada a Gòsol</description>
+</gpx_file>
+<gpx_file id="7797939" name="activity_11093847135.gpx" user="jmaspons" visibility="identifiable" pending="false" timestamp="2023-06-04T09:17:06Z" lat="31.136192930862308" lon="-7.927299840375781">
+  <description>Imlil - Tamsoult</description>
+</gpx_file>
+<gpx_file id="7797955" name="activity_11103300874.gpx" user="jmaspons" visibility="identifiable" pending="false" timestamp="2023-06-04T09:21:17Z" lat="31.063376488164067" lon="-7.937062913551927">
+  <description>Toubkal - Imlil</description>
+</gpx_file>
+<gpx_file id="7797946" name="activity_11102996506.gpx" user="jmaspons" visibility="identifiable" pending="false" timestamp="2023-06-04T09:19:07Z" lat="31.097403075546026" lon="-7.967628613114357">
+  <description>Tamsoult - Refuge Toubkal</description>
+</gpx_file>
+</osm>

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,3 +1,4 @@
 library(httptest2)
 
 set_osmapi_connection("testing")
+options(osmapir.R_CMD_check = TRUE)

--- a/tests/testthat/test-gps_traces.R
+++ b/tests/testthat/test-gps_traces.R
@@ -45,30 +45,11 @@ test_that("osm_delete_gpx works", {
 
 test_that("osm_get_metadata_gpx works", {
   with_mock_dir("mock_get_metadata_gpx", {
-    # trk_meta <- osm_get_metadata_gpx(gpx_id = 3790367)
+    trk_meta <- osm_get_metadata_gpx(gpx_id = 3790367)
   })
-  ## TODO: Error in authentication when testing??
-  # Error in `loadNamespace(x)`: there is no package called 'httpuv'
-  # Backtrace:
-  #   ▆
-  # 1. ├─httptest2::with_mock_dir(...) at test-gps_traces.R:40:2
-  # 2. │ ├─httptest2:::with_mock_path(...)
-  # 3. │ │ └─base::eval.parent(expr)
-  # 4. │ │   └─base::eval(expr, p)
-  # 5. │ └─httptest2::with_mock_api(expr)
-  # 6. │   └─base::eval.parent(expr)
-  # 7. │     └─base::eval(expr, p)
-  # 8. ├─osmapiR::osm_get_metadata_gpx(gpx_id = 3498170) at test-gps_traces.R:41:4
-  # 9. │ └─osmapiR:::osmapi_request(authenticate = TRUE)
-  # 10. │   └─osmapiR:::oauth_request(req)
-  # 11. │     └─httr2::req_oauth_auth_code(...)
-  # 12. └─base::loadNamespace(x)
-  # 13.   └─base::withRestarts(stop(cond), retry_loadNamespace = function() NULL)
-  # 14.     └─base (local) withOneRestart(expr, restarts[[1L]])
-  # 15.       └─base (local) doWithOneRestart(return(expr), restart)
 
-  # expect_s3_class(trk_meta, "data.frame")
-  # expect_named(trk_meta, column_meta_gpx)
+  expect_s3_class(trk_meta, "data.frame")
+  expect_named(trk_meta, column_meta_gpx)
 })
 
 
@@ -84,25 +65,6 @@ test_that("osm_get_data_gpx works", {
     # trk_data$gpx <- osm_get_data_gpx(gpx_id = 3458743, format = "gpx")
     # trk_data$xml <- osm_get_data_gpx(gpx_id = 3458743, format = "xml")
   })
-  ## TODO: Error in authentication when testing??
-  # Error in `loadNamespace(x)`: there is no package called 'httpuv'
-  # Backtrace:
-  #   ▆
-  # 1. ├─httptest2::with_mock_dir(...) at test-gps_traces.R:54:2
-  # 2. │ ├─httptest2:::with_mock_path(...)
-  # 3. │ │ └─base::eval.parent(expr)
-  # 4. │ │   └─base::eval(expr, p)
-  # 5. │ └─httptest2::with_mock_api(expr)
-  # 6. │   └─base::eval.parent(expr)
-  # 7. │     └─base::eval(expr, p)
-  # 8. ├─osmapiR::osm_get_data_gpx(gpx_id = 3498170) at test-gps_traces.R:55:4
-  # 9. │ └─osmapiR:::osmapi_request(authenticate = TRUE)
-  # 10. │   └─osmapiR:::oauth_request(req)
-  # 11. │     └─httr2::req_oauth_auth_code(...)
-  # 12. └─base::loadNamespace(x)
-  # 13.   └─base::withRestarts(stop(cond), retry_loadNamespace = function() NULL)
-  # 14.     └─base (local) withOneRestart(expr, restarts[[1L]])
-  # 15.       └─base (local) doWithOneRestart(return(expr), restart)
 
   # lapply(trk_data, expect_s3_class, "data.frame")
   # lapply(trk_data, expect_named, column_gpx)
@@ -113,27 +75,9 @@ test_that("osm_get_data_gpx works", {
 
 test_that("osm_list_gpxs works", {
   with_mock_dir("mock_list_gpxs", {
-    # traces <- osm_list_gpxs()
+    traces <- osm_list_gpxs()
   })
-  ## TODO: Error in authentication when testing??
-  # Backtrace:
-  #   ▆
-  # 1. ├─httptest2::with_mock_dir(...) at test-gps_traces.R:64:2
-  # 2. │ ├─httptest2:::with_mock_path(...)
-  # 3. │ │ └─base::eval.parent(expr)
-  # 4. │ │   └─base::eval(expr, p)
-  # 5. │ └─httptest2::with_mock_api(expr)
-  # 6. │   └─base::eval.parent(expr)
-  # 7. │     └─base::eval(expr, p)
-  # 8. ├─osmapiR::osm_list_gpxs() at test-gps_traces.R:65:4
-  # 9. │ └─osmapiR:::osmapi_request(authenticate = TRUE)
-  # 10. │   └─osmapiR:::oauth_request(req)
-  # 11. │     └─httr2::req_oauth_auth_code(...)
-  # 12. └─base::loadNamespace(x)
-  # 13.   └─base::withRestarts(stop(cond), retry_loadNamespace = function() NULL)
-  # 14.     └─base (local) withOneRestart(expr, restarts[[1L]])
-  # 15.       └─base (local) doWithOneRestart(return(expr), restart)
 
-  # expect_s3_class(traces, "data.frame")
-  # expect_named(traces, column_meta_gpx)
+  expect_s3_class(traces, "data.frame")
+  expect_named(traces, column_meta_gpx)
 })

--- a/tests/testthat/test-map_notes.R
+++ b/tests/testthat/test-map_notes.R
@@ -66,6 +66,7 @@ test_that("osm_close_note works", {
   })
 })
 
+
 ## Reopen: `POST /api/0.6/notes/#id/reopen` ----
 
 test_that("osm_reopen_note works", {

--- a/tests/testthat/test-miscellaneous.R
+++ b/tests/testthat/test-miscellaneous.R
@@ -41,28 +41,8 @@ test_that("osm_bbox_objects works", {
 
 test_that("osm_permissions works", {
   with_mock_dir("mock_permissions", {
-    # perms <- osm_permissions()
+    perms <- osm_permissions()
   })
-  ## TODO: Error in authentication when testing??
-  # Error in `loadNamespace(x)`: there is no package called 'httpuv'
-  # Backtrace:
-  #   ▆
-  # 1. ├─httptest2::with_mock_dir(...) at test-miscellaneous.R:43:2
-  # 2. │ ├─httptest2:::with_mock_path(...)
-  # 3. │ │ └─base::eval.parent(expr)
-  # 4. │ │   └─base::eval(expr, p)
-  # 5. │ └─httptest2::with_mock_api(expr)
-  # 6. │   └─base::eval.parent(expr)
-  # 7. │     └─base::eval(expr, p)
-  # 8. ├─osmapiR::osm_permissions() at test-miscellaneous.R:44:4
-  # 9. │ └─osmapiR:::osmapi_request(authenticate = TRUE)
-  # 10. │   └─osmapiR:::oauth_request(req)
-  # 11. │     └─httr2::req_oauth_auth_code(...)
-  # 12. └─base::loadNamespace(x)
-  # 13.   └─base::withRestarts(stop(cond), retry_loadNamespace = function() NULL)
-  # 14.     └─base (local) withOneRestart(expr, restarts[[1L]])
-  # 15.       └─base (local) doWithOneRestart(return(expr), restart)
 
-
-  # expect_type(perms, "character")
+  expect_type(perms, "character")
 })

--- a/tests/testthat/test-user_data.R
+++ b/tests/testthat/test-user_data.R
@@ -3,6 +3,7 @@ column_attrs <- c(
   "traces_count", "blocks_received.count", "blocks_received.active", "blocks_issued.count", "blocks_issued.active"
 )
 
+
 ## Details of a user: `GET /api/0.6/user/#id` ----
 
 test_that("osm_details_user works", {
@@ -30,38 +31,19 @@ test_that("osm_details_users works", {
 
 
 ## Details of the logged-in user: `GET /api/0.6/user/details` ----
-# WARNING: authenticated
+
 test_that("osm_details_logged_user works", {
   with_mock_dir("mock_details_logged_user", {
-    # usr_details <- osm_details_logged_user()
+    usr_details <- osm_details_logged_user()
   })
-  ## TODO: Error in authentication when testing??
-  # Error in `loadNamespace(x)`: there is no package called 'httpuv'
-  # Backtrace:
-  #   ▆
-  # 1. ├─httptest2::with_mock_dir(...) at test-user_data.R:35:2
-  # 2. │ ├─httptest2:::with_mock_path(...)
-  # 3. │ │ └─base::eval.parent(expr)
-  # 4. │ │   └─base::eval(expr, p)
-  # 5. │ └─httptest2::with_mock_api(expr)
-  # 6. │   └─base::eval.parent(expr)
-  # 7. │     └─base::eval(expr, p)
-  # 8. ├─osmapiR::osm_details_logged_user() at test-user_data.R:36:4
-  # 9. │ └─osmapiR:::osmapi_request(authenticate = TRUE)
-  # 10. │   └─osmapiR:::oauth_request(req)
-  # 11. │     └─httr2::req_oauth_auth_code(...)
-  # 12. └─base::loadNamespace(x)
-  # 13.   └─base::withRestarts(stop(cond), retry_loadNamespace = function() NULL)
-  # 14.     └─base (local) withOneRestart(expr, restarts[[1L]])
-  # 15.       └─base (local) doWithOneRestart(return(expr), restart)
 
-  # expect_type(usr_details, "list")
-  # expect_named(usr_details,
-  #   c(
-  #     "user", "description", "img", "contributor_terms", "roles",
-  #     "changesets", "traces", "blocks", "home", "languages", "messages"
-  #   )
-  # )
+  expect_type(usr_details, "list")
+  expect_named(usr_details,
+    c(
+      "user", "description", "img", "contributor_terms", "roles",
+      "changesets", "traces", "blocks", "home", "languages", "messages"
+    )
+  )
 })
 
 


### PR DESCRIPTION
Don't add httr2::req_oauth_auth_code on R-CMD-check

Avoid errors when testing calls using httptest2. The mock responses have to
be generated manually on an authenticated session