### PR TITLE
Update installign instructions

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -38,6 +38,7 @@ You can install the development version of osmapiR from [GitHub](https://github.
 
 ``` r
 # install.packages("remotes")
+# install.packages("rmarkdown") # Needed to build vignettes.
 remotes::install_github("jmaspons/osmapiR", build_vignettes = TRUE)
 ```
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -38,6 +38,9 @@ You can install the development version of osmapiR from [GitHub](https://github.
 
 ``` r
 # install.packages("remotes")
+remotes::install_github("jmaspons/osmapiR") # Without vignettes
+
+## With vignettes (also accessible at https://jmaspons.github.io/osmapiR/ > Articles)
 # install.packages("rmarkdown") # Needed to build vignettes.
 remotes::install_github("jmaspons/osmapiR", build_vignettes = TRUE)
 ```


### PR DESCRIPTION
With the latest change, installation fails if rmarkdown is not installed.
This small commit adds a mention to this. Another approach would be to make that package a required dependency.