### PR TITLE
Set core.autocrlf on windows GHA

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,6 +29,10 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
+      - name: Configure git
+        if: runner.os == 'Windows'
+        run: git config --global core.autocrlf false
+
       - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2

--- a/tests/testthat/test-gps_traces.R
+++ b/tests/testthat/test-gps_traces.R
@@ -60,17 +60,6 @@ test_that("osm_get_points_gps works", {
 
 
 test_that("edit gpx works", {
-  skip_on_os("windows") # TODO: issue in httptest2? different mock file name in windows
-  # https://github.com/nealrichardson/httptest2/issues/42
-  # Error in `stop_request(req)`: An unexpected request was made:
-  # POST https://master.apis.dev.openstreetmap.org/api/0.6/gpx/create Multipart form:
-  #   file = File: f42901c4e0e077e532e417da5224df67
-  #   description = Test create gpx with osmapiR.
-  #   tags = testing, osmapiR
-  #   visibility = private
-  #
-  # Expected mock file: osm.org/api/0.6/gpx/create-b3940a-POST.*
-
   gpx_path <- test_path("sample_files", "sample.gpx")
 
   with_mock_dir("mock_edit_gpx", {


### PR DESCRIPTION
I stumbled across https://github.com/nealrichardson/httptest2/blob/main/.github/workflows/R-CMD-check.yaml#L30-L32 just now and realized that could be the source of https://github.com/nealrichardson/httptest2/issues/42 for you--when git clones, it inserts CRLF on Windows by default. Let's see if this fixes things.